### PR TITLE
chore: remove vscode and some gnome extensions

### DIFF
--- a/remove-pkgs
+++ b/remove-pkgs
@@ -1,4 +1,15 @@
+code
 gnome-shell-extension-appindicator
+gnome-shell-extension-bazzite-menu
 gnome-shell-extension-blur-my-shell
-clapper
+gnome-shell-extension-burn-my-windows
+gnome-shell-extension-compiz-alike-magic-lamp-effect
+gnome-shell-extension-compiz-windows-effect
+gnome-shell-extension-desktop-cube
+gnome-shell-extension-hotedge
+gnome-shell-extension-just-perfection
+gnome-shell-extension-launch-new-instance
+gnome-shell-extension-places-menu
+gnome-shell-extension-restart-to
+gnome-shell-extension-window-list
 ptyxis


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded the list of packages scheduled for removal by adding several GNOME Shell extensions and the "clapper" package.
  - Added a new entry labeled "code" at the top of the removal list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->